### PR TITLE
Remove grailsPublish from skeleton

### DIFF
--- a/skeleton/build.gradle
+++ b/skeleton/build.gradle
@@ -1,14 +1,2 @@
 // enable if you wish to package this plugin as a standalone application
 bootJar.enabled = false
-grailsPublish {
-    // TODO: Provide values here
-    user = 'user'
-    key = 'key'
-    githubSlug = 'foo/bar'
-    license {
-        name = 'Apache-2.0'
-    }
-    title = "My Plugin"
-    desc = "Full plugin description"
-    developers = [johndoe:"John Doe"]
-}


### PR DESCRIPTION
The grails-publish-plugin is removed, so the grailsPublish block does not make any sense.